### PR TITLE
Use JSON for tag and feedback requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ _test
 *.[568vq]
 [568vq].out
 
+# IntelliJ
+*.iml
+.idea
+
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c
@@ -24,5 +28,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.sw[nop]
 
 mct.go

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func main() {
 	// Let's get some context about these images
 	urls := []string{"http://www.clarifai.com/img/metro-north.jpg", "http://www.clarifai.com/img/metro-north.jpg"}
 	// Give it to Clarifai to run their magic
-	tag_data, err := client.Tag(urls, nil)
+	tag_data, err := client.Tag(clarifai.TagRequest{URLs: urls})
 
 	if err != nil {
 		fmt.Println(err)

--- a/requests.go
+++ b/requests.go
@@ -29,6 +29,7 @@ type InfoResp struct {
 type TagRequest struct {
 	URLs     []string `json:"url"`
 	LocalIDs []string `json:"local_ids,omitempty"`
+	Model    string   `json:"model,omitempty"`
 }
 
 // TagResp represents the expected JSON response from /tag/

--- a/requests_test.go
+++ b/requests_test.go
@@ -55,7 +55,7 @@ func TestTagMultiple(t *testing.T) {
 	})
 
 	urls := []string{"http://www.clarifai.com/img/metro-north.jpg", "http://www.clarifai.com/img/metro-north.jpg"}
-	_, err := client.Tag(urls, nil)
+	_, err := client.Tag(TagRequest{URLs: urls})
 
 	if err != nil {
 		t.Errorf("Tag() should not return error with valid request: %q\n", err)


### PR DESCRIPTION
I switched tag and feedback requests to use JSON rather than form data.
(The API supports both.) This simplifies request construction and makes
it easier to add more request parameters later.

This is a breaking change for the Tag function, but it should help
avoid more breaking changes in the future.