### PR TITLE
Images and Videos tag response inconsistency

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -123,6 +123,11 @@ func (client *Client) Info() (*InfoResp, error) {
 }
 
 // Tag allows the client to request tag data on a single, or multiple photos
+func (client *Client) Tag(req TagRequest) (*ImageTagResp, error) {
+	return client.ImageTag(req)
+}
+
+// ImageTag allows the client to request tag data on a single, or multiple photos
 func (client *Client) ImageTag(req TagRequest) (*ImageTagResp, error) {
 	if len(req.URLs) < 1 {
 		return nil, errors.New("Requires at least one url")
@@ -140,7 +145,7 @@ func (client *Client) ImageTag(req TagRequest) (*ImageTagResp, error) {
 	return tagres, err
 }
 
-// Tag allows the client to request tag data on a single, or multiple photos
+// VideoTag allows the client to request tag data on a single, or multiple videos
 func (client *Client) VideoTag(req TagRequest) (*VideoTagResp, error) {
 	if len(req.URLs) < 1 {
 		return nil, errors.New("Requires at least one url")


### PR DESCRIPTION
This pull request adds `ImageTag()` and `VideoTag()` methods and parallel model structures for image and video tag response. The existing `Tag()` method will return the same structure (but now the struct is named `ImageTag`).

The problem is explained here: https://github.com/Clarifai/clarifai-go/issues/10