### PR TITLE
Add support for color endpoint and file uploads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,53 @@ package main
 import (
 	"fmt"
 
-	"github.com/clarifai/clarifai-go"
+	"github.com/Clarifai/clarifai-go"
 )
 
 func main() {
 	client := clarifai.NewClient("<client_id>", "<client_secret>")
-	// Get the current status of things
+
+	// Get the current status of things.
 	info, err := client.Info()
 	if err != nil {
 		fmt.Println(err)
 	} else {
 		fmt.Printf("%+v\n", info)
 	}
-	// Let's get some context about these images
-	urls := []string{"http://www.clarifai.com/img/metro-north.jpg", "http://www.clarifai.com/img/metro-north.jpg"}
-	// Give it to Clarifai to run their magic
-	tag_data, err := client.Tag(clarifai.TagRequest{URLs: urls})
 
+	// Let's get some context about these images.
+	urls := []string{"http://www.clarifai.com/img/metro-north.jpg", "http://www.clarifai.com/img/metro-north.jpg"}
+
+	// Files are also supported, but you must issue a different request.
+	// files := []string{"mountain.jpg", "landscape.png"}
+
+	// Give it to Clarifai to run their magic.
+	tagData, err := client.Tag(clarifai.TagRequest{
+		// Files: files,
+		URLs: urls,
+	})
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		fmt.Printf("%+v\n", tag_data) // See what we got!
+		fmt.Printf("%+v\n", tagData) // See what we got!
 	}
 
+	// Grab color data from Clarifai as well!
+	colorData, err := client.Color(clarifai.ColorRequest{
+		// Files, files,
+		URLs: urls,
+	})
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("%+v\n", colorData) // See what we got!
+	}
+
+	// Provide feedback about the images.
 	feedback_data, err := client.Feedback(clarifai.FeedbackForm{
 		URLs:    urls,
 		AddTags: []string{"cat", "animal"},
 	})
-
 	if err != nil {
 		fmt.Println(err)
 	} else {

--- a/client.go
+++ b/client.go
@@ -121,6 +121,7 @@ func (client *Client) commonHTTPRequest(jsonBody interface{}, endpoint, verb str
 		}
 		defer res.Body.Close()
 		body, err := ioutil.ReadAll(res.Body)
+
 		return body, err
 	case 401:
 		if !retry {
@@ -143,11 +144,11 @@ func (client *Client) commonHTTPRequest(jsonBody interface{}, endpoint, verb str
 	}
 }
 
-func (client *Client) fileHTTPRequest(jsonBody TagRequest, endpoint string, retry bool) ([]byte, error) {
+func (client *Client) fileHTTPRequest(jsonBody hasFiles, endpoint string, retry bool) ([]byte, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	for idx, file := range jsonBody.Files {
+	for idx, file := range jsonBody.GetFiles() {
 		// don't share file name information
 		fileWriter, err := writer.CreateFormFile("encoded_data", strconv.Itoa(idx))
 		if err != nil {


### PR DESCRIPTION
This PR does a few things.
- Adds file upload support for tag/color endpoints.
- Adds full support for the color endpoint via the `Color()` method.
- Adds tests to verify color support.
- Updates README.md to show examples of new functionality.
