### PR TITLE
Update README example code to use working image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ func main() {
 		fmt.Printf("%+v\n", info)
 	}
 	// Let's get some context about these images
-	urls := []string{"http://www.clarifai.com/img/metro-north.jpg", "http://www.clarifai.com/img/metro-north.jpg"}
+	urls := []string{"https://samples.clarifai.com/metro-north.jpg", "https://samples.clarifai.com/puppy.jpeg"}
 	// Give it to Clarifai to run their magic
 	tag_data, err := client.Tag(clarifai.TagRequest{URLs: urls})
 


### PR DESCRIPTION
I was trying out the library and was surprised to discover that the URLs in the README example are broken (I'm guessing you guys changed where you hosted them somewhat recently).    When I tried running the code from the example I got a somewhat vague error, with no indication that the URLs just weren't pointing to images.

In any case, I thought I'd update the docs to use working image URLs.